### PR TITLE
Updated where `get_current_site` is imported from

### DIFF
--- a/fastsitemaps/views.py
+++ b/fastsitemaps/views.py
@@ -2,7 +2,10 @@ from django.core import urlresolvers
 from django.core.paginator import EmptyPage, PageNotAnInteger
 from django.http import Http404, HttpResponse
 from django.template.response import TemplateResponse
-from django.contrib.sites.models import get_current_site
+try:
+    from django.contrib.sites.shortcuts import get_current_site
+except ImportError:  # < Django 1.7
+    from django.contrib.sites.models import get_current_site
 from django.conf import settings
 from fastsitemaps.generator import sitemap_generator
 from fastsitemaps.sitemaps import RequestSitemap


### PR DESCRIPTION
Fixes an ImportError raised in Django `master` (targetting 1.9) that was part of a deprecation cycle begun in 1.7.0 to separate bits of the `contrib.sites` package into distinct sensible modules.
